### PR TITLE
use Dancer qw(!pass) to avoid clashing with Test::More

### DIFF
--- a/t/cart.t
+++ b/t/cart.t
@@ -6,7 +6,7 @@ use warnings;
 use Test::More tests => 40;
 use Interchange6::Schema;
 
-use Dancer qw(:syntax);
+use Dancer qw(:syntax !pass);
 use Dancer::Plugin::Interchange6;
 
 use Data::Dumper;

--- a/t/shop-db.t
+++ b/t/shop-db.t
@@ -8,7 +8,7 @@ use DBICx::TestDatabase;
 use Interchange6::Schema;
 use Interchange6::Schema::Populate::CountryLocale;
 
-use Dancer ':syntax';
+use Dancer qw(:syntax !pass);
 use Dancer::Plugin::Interchange6;
 
 my @all_handles = Test::Database->handles();


### PR DESCRIPTION
Small patch to two tests to remove warning due to Dancer::pass clashing with Test::More::pass
