### PR TITLE
remove create and last_modified from _create_cart since backend will handle and inserting epoch values barfs Pg

### DIFF
--- a/lib/Dancer/Plugin/Interchange6/Cart/DBIC.pm
+++ b/lib/Dancer/Plugin/Interchange6/Cart/DBIC.pm
@@ -124,8 +124,6 @@ sub _create_cart {
     my %cart;
 
     %cart = (name => $self->name,
-             created => $self->created,
-             last_modified => $self->last_modified,
              sessions_id => $self->{session_id},
              );
 


### PR DESCRIPTION
Small fix to handle problem with cart trying to insert epoch times into Pg timestamp column
