### PR TITLE
change price values from decimal string to float in routes.t

### DIFF
--- a/t/routes/routes.t
+++ b/t/routes/routes.t
@@ -12,6 +12,7 @@ use warnings;
 
 use Test::Most tests => 67;
 
+use DBD::SQLite;
 use File::Spec;
 use Data::Dumper;
 use File::Temp 'tempfile';
@@ -23,6 +24,8 @@ use Interchange6::Schema::Populate::CountryLocale;
 
 use Dancer qw/:tests/;
 use Dancer::Plugin::Interchange6;
+
+diag( "Testing with DBD::SQLite $DBD::SQLite::VERSION" );
 
 my ( $filename, $resp, $sessionid, %form );
 


### PR DESCRIPTION
Maybe this will fix #14 though that issue could also be caused by sqlite's lack of real numeric (it actually uses float) or some other problem. At least this removes one coercion on our side so fewer potential points of failure.
