### PR TITLE
add product variant to cart without attributes/values

### DIFF
--- a/t/lib/Test/Routes.pm
+++ b/t/lib/Test/Routes.pm
@@ -149,6 +149,20 @@ test 'route tests' => sub {
     response_headers_include $resp => [ Location => 'http://localhost/' ],
       "Check redirect path";
 
+    # add variant using variant sku
+    %form = ( sku => 'os28004-HUM-BLK', );
+    lives_ok { $resp = dancer_response( POST => '/cart', { body => {%form} } ) }
+    "POST /cart add Ergo Roller human black using variant's sku only";
+    response_status_is $resp => 200, 'status is ok';
+    response_content_like $resp => qr/cart_total="64/, 'cart_total is 64.00';
+
+    # remove the variant
+    %form = ( remove => 'os28004-HUM-BLK', );
+    lives_ok { $resp = dancer_response( POST => '/cart', { body => {%form} } ) }
+    "POST /cart remove Ergo Roller human black using variant's sku only";
+    response_status_is $resp => 200, 'status is ok';
+    response_content_like $resp => qr/cart_total="48/, 'cart_total is 48.00';
+
     # GET /cart
     lives_ok { $resp = dancer_response GET => '/cart' } "GET /cart";
 


### PR DESCRIPTION
Now I've finally played with attributes and attribute_values and it hurt. The join in this patch results in one attribute name per attribute but multiple attribute values.

It works and gives us something to think about.
